### PR TITLE
Fix utils test imports

### DIFF
--- a/functions/src/utils.test.ts
+++ b/functions/src/utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { sendEmail, getAliasEmailAddress, getImapClient } from "./utils.js";
-import { SecretProvider } from "./config.js";
+import { sendEmail, getAliasEmailAddress, getImapClient } from "./utils";
+import { SecretProvider } from "./config";
 
 vi.mock("nodemailer", () => ({
   default: {


### PR DESCRIPTION
## Summary
- remove `.js` extension from utils and config imports in utils.test.ts

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6858dc670b64833189af82eb470523b9