### PR TITLE
Add reply for existing pets

### DIFF
--- a/functions/src/emailService.test.ts
+++ b/functions/src/emailService.test.ts
@@ -38,4 +38,29 @@ describe("processEmailMessage", () => {
     expect(mockProcessor.checkExistingPet).not.toHaveBeenCalled();
     expect(mockProcessor.createPet).not.toHaveBeenCalled();
   });
+
+  it("responds when pet already exists", async () => {
+    const mockProcessor: EmailProcessor = {
+      checkExistingPet: vi.fn().mockResolvedValue(true),
+      createPet: vi.fn(),
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.mocked(simpleParser).mockResolvedValue({
+      from: { value: [{ address: "user@example.com" }] },
+      subject: "こんにちは",
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const existingMock = vi
+      .spyOn(petService, "sendExistingPetEmail")
+      .mockResolvedValue();
+
+    const stream = Readable.from("dummy");
+    await processEmailMessage(stream, 1, mockProcessor);
+
+    expect(mockProcessor.checkExistingPet).toHaveBeenCalledWith("user@example.com");
+    expect(existingMock).toHaveBeenCalledWith("user@example.com");
+    expect(mockProcessor.createPet).not.toHaveBeenCalled();
+  });
 });

--- a/functions/src/emailService.ts
+++ b/functions/src/emailService.ts
@@ -14,7 +14,11 @@ import {
   SecretProvider,
   FirebaseSecretProvider,
 } from "./config";
-import { deletePetByEmail, sendUnsubscribeEmail } from "./petService";
+import {
+  deletePetByEmail,
+  sendUnsubscribeEmail,
+  sendExistingPetEmail,
+} from "./petService";
 import { EmailProcessor } from "./types";
 
 export class FirestoreEmailProcessor implements EmailProcessor {
@@ -66,6 +70,7 @@ export async function processEmailMessage(
   const petExists = await processor.checkExistingPet(senderEmail);
   if (petExists) {
     console.log(`Pet already exists for ${senderEmail}`);
+    await sendExistingPetEmail(senderEmail);
     return;
   }
 

--- a/functions/src/petService.test.ts
+++ b/functions/src/petService.test.ts
@@ -92,6 +92,23 @@ describe("sendUnsubscribeEmail", () => {
   });
 });
 
+describe("sendExistingPetEmail", () => {
+  it("should call sendEmail with notice subject", async () => {
+    const sendEmailMock = vi.spyOn(emailUtils, "sendEmail").mockResolvedValue();
+    const email = "user@example.com";
+
+    await petService.sendExistingPetEmail(email);
+
+    expect(sendEmailMock).toHaveBeenCalledWith(
+      email,
+      "[旅ペット登録済み]",
+      expect.stringContaining("登録されています")
+    );
+
+    sendEmailMock.mockRestore();
+  });
+});
+
 describe("deletePetByEmail", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/functions/src/petService.ts
+++ b/functions/src/petService.ts
@@ -30,6 +30,18 @@ export async function sendUnsubscribeEmail(email: string): Promise<void> {
   console.log(`Unsubscribe confirmation sent to: ${email}`);
 }
 
+export async function sendExistingPetEmail(email: string): Promise<void> {
+  const subject = "[旅ペット登録済み]";
+  const body = `
+こんにちは！
+
+既に旅ペットを登録されています。\n引き続き旅をお楽しみください！\n\n旅ペットチーム
+`;
+
+  await sendEmail(email, subject, body);
+  console.log(`Existing pet notice sent to: ${email}`);
+}
+
 // Delete pets whose lifetime exceeds PET_LIFESPAN_DAYS
 export async function deleteExpiredPets(): Promise<void> {
   const petsSnapshot = await db.collection("pets").get();


### PR DESCRIPTION
## Summary
- reply with a notice if a sender already has a pet registered
- test sendExistingPetEmail utility
- test reply flow in emailService

## Testing
- `npm run test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685cb5a9cd9c83318737974b383080f3