### PR TITLE
Add cat image generation endpoint

### DIFF
--- a/functions/src/generateCatImage.ts
+++ b/functions/src/generateCatImage.ts
@@ -1,0 +1,30 @@
+import { ai } from "./genkit.config";
+import { gemini } from "@genkit-ai/vertexai";
+import { z } from "zod";
+
+const OutputSchema = ai.defineSchema(
+  "GenerateImageOutput",
+  z.object({ url: z.string() })
+);
+
+export const generateCatImage = ai.defineFlow(
+  {
+    name: "generateCatImage",
+    inputSchema: ai.defineSchema("GenerateImageInput", z.object({})),
+    outputSchema: OutputSchema,
+  },
+  async () => {
+    const result = await ai.generate({
+      model: gemini("gemini-2.0-flash-preview-image-generation"),
+      prompt: "絵日記風のかわいい猫のイラストを描いてください",
+    });
+
+    const url =
+      result.message?.content.find((p) => "media" in p && p.media)?.media?.url;
+
+    if (!url) {
+      throw new Error("Failed to generate image");
+    }
+    return { url };
+  }
+);

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -8,6 +8,7 @@ import {
 } from "./diaryService";
 import { deleteExpiredPets } from "./petService";
 import { EMAIL_ADDRESS, EMAIL_APP_PASSWORD } from "./config";
+import { generateCatImage } from "./generateCatImage";
 
 export { db } from "./firebase";
 
@@ -126,4 +127,19 @@ export const manualDiaryGeneration = onRequest(
 // onRequest動作確認用
 export const helloWorld = onRequest(async (_req, res) => {
   res.status(200).send("✅ Hello from Gen 2 Cloud Functions!");
+});
+
+export const catImage = onRequest(async (_req, res) => {
+  try {
+    const { url } = await generateCatImage();
+    const [meta, data] = url.split(",");
+    const match = meta.match(/data:(.*);base64/);
+    const mimeType = match ? match[1] : "image/png";
+    const buffer = Buffer.from(data, "base64");
+    res.setHeader("Content-Type", mimeType);
+    res.status(200).send(buffer);
+  } catch (error) {
+    console.error("Image generation failed:", error);
+    res.status(500).send("Image generation failed");
+  }
 });


### PR DESCRIPTION
## Summary
- create `generateCatImage` flow using Vertex AI Imagen
- expose `catImage` HTTP function to return generated image
- switch cat image flow to gemini instead of Imagen

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685cd00dfe388331b2371e2657e708c3