### PR TITLE
Fix public image URL

### DIFF
--- a/functions/src/diaryHelpers.ts
+++ b/functions/src/diaryHelpers.ts
@@ -51,7 +51,8 @@ export async function saveImageToStorage(
   const filePath = `diaryImages/${petId}/${date}.png`;
   const file = bucket.file(filePath);
   await file.save(buffer, { contentType: "image/png" });
-  return file.publicUrl();
+  const encodedPath = encodeURIComponent(filePath);
+  return `https://firebasestorage.googleapis.com/v0/b/${bucket.name}/o/${encodedPath}?alt=media`;
 }
 
 // 分離されたFirestore保存関数


### PR DESCRIPTION
## Summary
- ensure saveImageToStorage returns the correct media URL for Firebase Storage

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685d1963a0488331ae6f208229a3644a