### PR TITLE
Improve email templates

### DIFF
--- a/functions/src/createPetFlow.test.ts
+++ b/functions/src/createPetFlow.test.ts
@@ -70,7 +70,10 @@ describe("createPetFlow helpers", () => {
       expect(sendEmailMock).toHaveBeenCalledWith(
         email,
         "[旅ペット作成完了]",
-        expect.stringContaining(JSON.stringify(profile))
+        expect.stringContaining(profile.name),
+        undefined,
+        undefined,
+        { html: expect.stringContaining(profile.name) }
       );
 
       sendEmailMock.mockRestore();

--- a/functions/src/createPetFlow.ts
+++ b/functions/src/createPetFlow.ts
@@ -70,18 +70,24 @@ export async function sendPetCreationEmail(
 ): Promise<void> {
   const subject = "[旅ペット作成完了]";
   const body = `
-こんにちは！
+こんにちは、たびぺっち運営チームです。
 
-あなたの旅ペットが誕生しました🎉
+あなたの旅ペット「${profile.name}」が誕生しました！
 
-${JSON.stringify(profile)}
+${profile.introduction}
 
 これからこのペットが毎日旅日記をお届けします。
-どんな冒険が待っているか、お楽しみに！
+どんな冒険が待っているか、お楽しみに。
 
-旅ペットチーム
+旅するデジタルペット『たびぺっち』チーム
 `;
 
-  await sendEmail(email, subject, body);
+  // eslint-disable-next-line quotes
+  const htmlBody = `<p>こんにちは、たびぺっち運営チームです。</p><p>あなたの旅ペット「${profile.name}」が誕生しました！</p><p>${profile.introduction.replace(
+    /\n/g,
+    "<br>"
+  )}</p><p>これからこのペットが毎日旅日記をお届けします。<br>どんな冒険が待っているか、お楽しみに。</p><p>旅するデジタルペット『たびぺっち』チーム</p>`;
+
+  await sendEmail(email, subject, body, undefined, undefined, { html: htmlBody });
   console.log(`Creation email sent to: ${email}`);
 }

--- a/functions/src/diaryHelpers.test.ts
+++ b/functions/src/diaryHelpers.test.ts
@@ -177,7 +177,7 @@ describe("diary helpers", () => {
         expect.stringContaining(diary),
         undefined,
         undefined,
-        { html: undefined }
+        { html: expect.stringContaining(diary) }
       );
 
       sendEmailMock.mockRestore();

--- a/functions/src/diaryHelpers.ts
+++ b/functions/src/diaryHelpers.ts
@@ -118,24 +118,26 @@ export async function sendDiaryEmail(
   const location = itinerary.selected_location ?? "";
   const subject = `[旅日記] ${location}`;
   const body = `
-こんにちは！
+こんにちは、たびぺっち運営チームです。
 
-今日の旅日記をお届けします📖
+あなたの旅ペットから本日の旅の便りが届きました。
+${location ? `今回は「${location}」を訪れています。` : ""}
 
 ${diary}
 
-それでは、また明日の冒険をお楽しみに！
+明日はどんな景色を見せてくれるのでしょうか。
+楽しみにお待ちください。
 
-あなたの旅ペットより
+旅するデジタルペット『たびぺっち』チーム
 `;
 
-  let htmlBody: string | undefined;
-  if (imageUrl) {
-    htmlBody = `<p>こんにちは！</p><p>今日の旅日記をお届けします📖</p><p>${diary.replace(
-      /\n/g,
-      "<br>"
-    )}</p><img src="${imageUrl}" alt="diary image"/><p>それでは、また明日の冒険をお楽しみに！</p><p>あなたの旅ペットより</p>`;
-  }
+  const locationLine = location ? `<p>今回は「${location}」を訪れています。</p>` : "";
+  const imageTag = imageUrl ? `<img src="${imageUrl}" alt="diary image"/>` : "";
+  // eslint-disable-next-line quotes
+  const htmlBody = `<p>こんにちは、たびぺっち運営チームです。</p><p>あなたの旅ペットから本日の旅の便りが届きました。</p>${locationLine}<p>${diary.replace(
+    /\n/g,
+    "<br>"
+  )}</p>${imageTag}<p>明日はどんな景色を見せてくれるのでしょうか。<br>楽しみにお待ちください。</p><p>旅するデジタルペット『たびぺっち』チーム</p>`;
 
   await sendEmail(email, subject, body, undefined, undefined, {
     html: htmlBody,

--- a/functions/src/petService.test.ts
+++ b/functions/src/petService.test.ts
@@ -53,7 +53,10 @@ describe("deleteExpiredPets", () => {
     expect(sendEmailMock).toHaveBeenCalledWith(
       oldPet.data().email,
       "[旅ペットとのお別れ]",
-      expect.any(String)
+      expect.any(String),
+      undefined,
+      undefined,
+      { html: expect.any(String) }
     );
   });
 });
@@ -68,7 +71,10 @@ describe("sendFarewellEmail", () => {
     expect(sendEmailMock).toHaveBeenCalledWith(
       email,
       "[旅ペットとのお別れ]",
-      expect.stringContaining("冒険は終了")
+      expect.stringContaining("冒険は終了"),
+      undefined,
+      undefined,
+      { html: expect.any(String) }
     );
 
     sendEmailMock.mockRestore();
@@ -85,7 +91,10 @@ describe("sendUnsubscribeEmail", () => {
     expect(sendEmailMock).toHaveBeenCalledWith(
       email,
       "[旅ペット配信停止完了]",
-      expect.stringContaining("配信停止")
+      expect.stringContaining("配信停止"),
+      undefined,
+      undefined,
+      { html: expect.any(String) }
     );
 
     sendEmailMock.mockRestore();
@@ -102,7 +111,10 @@ describe("sendExistingPetEmail", () => {
     expect(sendEmailMock).toHaveBeenCalledWith(
       email,
       "[旅ペット登録済み]",
-      expect.stringContaining("登録されています")
+      expect.stringContaining("登録されています"),
+      undefined,
+      undefined,
+      { html: expect.any(String) }
     );
 
     sendEmailMock.mockRestore();

--- a/functions/src/petService.ts
+++ b/functions/src/petService.ts
@@ -6,39 +6,56 @@ import { sendEmail } from "./email";
 export async function sendFarewellEmail(email: string): Promise<void> {
   const subject = "[旅ペットとのお別れ]";
   const body = `
-こんにちは！
+こんにちは、たびぺっち運営チームです。
 
-あなたの旅ペットとの冒険は終了しました。
-今まで一緒に旅をしていただき、ありがとうございました。
+長い間ご一緒いただいた旅ペットとの冒険は終了しました。
+これまで一緒に旅をしていただき、心より感謝申し上げます。
 
-旅ペットチーム
+またお会いできる日を楽しみにしております。
+
+旅するデジタルペット『たびぺっち』チーム
 `;
 
-  await sendEmail(email, subject, body);
+  // eslint-disable-next-line quotes
+  const htmlBody = `<p>こんにちは、たびぺっち運営チームです。</p><p>長い間ご一緒いただいた旅ペットとの冒険は終了しました。<br>これまで一緒に旅をしていただき、心より感謝申し上げます。</p><p>またお会いできる日を楽しみにしております。</p><p>旅するデジタルペット『たびぺっち』チーム</p>`;
+
+  await sendEmail(email, subject, body, undefined, undefined, { html: htmlBody });
   console.log(`Farewell email sent to: ${email}`);
 }
 
 export async function sendUnsubscribeEmail(email: string): Promise<void> {
   const subject = "[旅ペット配信停止完了]";
   const body = `
-こんにちは！
+こんにちは、たびぺっち運営チームです。
 
-旅ペットの配信停止を承りました。\n今までご利用いただき、ありがとうございました。\n\n旅ペットチーム
+旅ペットの配信停止を承りました。
+これまでサービスをご利用いただき、誠にありがとうございました。
+
+旅するデジタルペット『たびぺっち』チーム
 `;
 
-  await sendEmail(email, subject, body);
+  // eslint-disable-next-line quotes
+  const htmlBody = `<p>こんにちは、たびぺっち運営チームです。</p><p>旅ペットの配信停止を承りました。<br>これまでサービスをご利用いただき、誠にありがとうございました。</p><p>旅するデジタルペット『たびぺっち』チーム</p>`;
+
+  await sendEmail(email, subject, body, undefined, undefined, { html: htmlBody });
   console.log(`Unsubscribe confirmation sent to: ${email}`);
 }
 
 export async function sendExistingPetEmail(email: string): Promise<void> {
   const subject = "[旅ペット登録済み]";
   const body = `
-こんにちは！
+こんにちは、たびぺっち運営チームです。
 
-既に旅ペットを登録されています。\n引き続き旅をお楽しみください！\n\n旅ペットチーム
+既に旅ペットを登録されています。
+引き続き、旅先からの便りをお楽しみください。
+
+旅するデジタルペット『たびぺっち』チーム
 `;
 
-  await sendEmail(email, subject, body);
+  // eslint-disable-next-line quotes
+  const htmlBody = `<p>こんにちは、たびぺっち運営チームです。</p><p>既に旅ペットを登録されています。<br>引き続き、旅先からの便りをお楽しみください。</p><p>旅するデジタルペット『たびぺっち』チーム</p>`;
+
+  await sendEmail(email, subject, body, undefined, undefined, { html: htmlBody });
   console.log(`Existing pet notice sent to: ${email}`);
 }
 


### PR DESCRIPTION
## Summary
- update pet creation and notification emails to include HTML content
- always include HTML diary entries
- update tests accordingly

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685e34c3fb548331860e771a96d58378