### PR TITLE
fix: improve diary email layout

### DIFF
--- a/functions/src/diaryHelpers.ts
+++ b/functions/src/diaryHelpers.ts
@@ -136,7 +136,9 @@ ${diary}
   const locationLine = location
     ? `<p>今回は「${location}」を訪れています。</p>`
     : "";
-  const imageTag = imageUrl ? `<img src="${imageUrl}" alt="diary image"/>` : "";
+  const imageTag = imageUrl
+    ? `<img src="${imageUrl}" alt="diary image" style="display:block;margin-top:0.5em;"/>`
+    : "";
   const diaryHtml = diary.replace(/\n/g, "<br>");
   const diarySection = `<div style="border:1px solid #eee;padding:1em;margin:1em 0;background:#fafafa;font-family:serif;line-height:1.6;">${diaryHtml}${imageTag}</div>`;
   // eslint-disable-next-line quotes


### PR DESCRIPTION
## Summary
- add margin above diary images in email body

## Testing
- `npm run test --prefix functions`
- `npm run lint --prefix functions`

------
https://chatgpt.com/codex/tasks/task_e_68609153da1c83318a09798f826d6810