### PR TITLE
Organize Genkit flows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,9 +43,11 @@ Travel Pet digital companion service that creates virtual pets for users and sen
 │   │   ├── generate-destination.prompt # Prompt for generating travel destinations
 │   │   └── generate-diary.prompt     # Prompt for generating diary entries
 │   ├── src/                  # Source code for Firebase Cloud Functions
-│   │   ├── createPetFlow.ts       # Pet creation logic (editable)
-│   │   ├── generateDestinationFlow.ts # Destination generation flow
-│   │   ├── generateDiaryFlow.ts  # Diary generation flow
+│   │   ├── flows/            # Genkit flow definitions
+│   │   │   ├── createPetFlow.ts       # Pet creation logic (editable)
+│   │   │   ├── generateDestinationFlow.ts # Destination generation flow
+│   │   │   ├── generateDiaryFlow.ts  # Diary generation flow
+│   │   │   └── generateDiaryImageFlow.ts # Diary image generation flow
 │   │   ├── diaryHelpers.ts     # Firestore and email helpers for diaries
 │   │   ├── diaryService.ts       # Destination & diary orchestration
 │   │   ├── genkit.config.ts  # Genkit plugin and flow configuration

--- a/README.md
+++ b/README.md
@@ -112,15 +112,15 @@ npm run deploy
 1.  **ペットの誕生 ([`emailCheckTrigger`](functions/src/index.ts#L14-L28))**:
     - ユーザーが `your-email+travel-pet@gmail.com` にメールを送信。
     - Cloud Schedulerで`emailCheckTrigger`をトリガーすることで、IMAPでメールを定期的に検知。（10分間隔）
-    - [`createPetFlow`](functions/src/createPetFlow.ts) が実行され、Geminiがペットのプロフィールを生成。
+    - [`createPetFlow`](functions/src/flows/createPetFlow.ts) が実行され、Geminiがペットのプロフィールを生成。
     - Firestoreにペットのデータが保存される。
     - `配信停止`もここで同時に検知し、ペットデータを削除。
 
 2.  **日記の生成 ([`dailyDiaryTrigger`](functions/src/index.ts#L30-L44))**:
     - 毎日、Cloud Schedulerがこのフローをトリガー。（午前5時30分）
     - [`generateDiariesForAllPets`](functions/src/diaryService.ts#L15-L67) が実行され、各ペットに対して以下の処理を行う:
-        - [`generateDestinationFlow`](functions/src/generateDestinationFlow.ts) でGeminiがランダムな旅先を生成。
-        - [`generateDiaryFlow`](functions/src/generateDiaryFlow.ts) でGeminiが日記の文章を、[`generateDiaryImageFlow`](functions/src/generateDiaryImageFlow.ts)でImagenが画像を生成。
+        - [`generateDestinationFlow`](functions/src/flows/generateDestinationFlow.ts) でGeminiがランダムな旅先を生成。
+        - [`generateDiaryFlow`](functions/src/flows/generateDiaryFlow.ts) でGeminiが日記の文章を、[`generateDiaryImageFlow`](functions/src/flows/generateDiaryImageFlow.ts)でImagenが画像を生成。
     - 生成された日記データはFirestoreに保存される。
 
 3.  **日記のメール送信 ([`dailyDiaryEmailTrigger`](functions/src/index.ts#L46-L60))**:

--- a/functions/src/createPetFlow.test.ts
+++ b/functions/src/createPetFlow.test.ts
@@ -3,7 +3,10 @@ import { Timestamp } from "firebase-admin/firestore";
 import * as index from "./index";
 import * as emailUtils from "./email";
 
-import { savePetToFirestore, sendPetCreationEmail } from "./createPetFlow";
+import {
+  savePetToFirestore,
+  sendPetCreationEmail,
+} from "./flows/createPetFlow";
 
 // Mocks for Firestore
 const setMock = vi.fn().mockResolvedValue(undefined);

--- a/functions/src/diaryService.ts
+++ b/functions/src/diaryService.ts
@@ -1,7 +1,7 @@
 import { db } from "./firebase";
-import { generateDestinationFlow } from "./generateDestinationFlow";
-import { generateDiaryFlow } from "./generateDiaryFlow";
-import { generateDiaryImageFlow } from "./generateDiaryImageFlow";
+import { generateDestinationFlow } from "./flows/generateDestinationFlow";
+import { generateDiaryFlow } from "./flows/generateDiaryFlow";
+import { generateDiaryImageFlow } from "./flows/generateDiaryImageFlow";
 import {
   getPetFromFirestore,
   saveDestinationToFirestore,

--- a/functions/src/emailService.ts
+++ b/functions/src/emailService.ts
@@ -5,7 +5,7 @@ import {
   createPetFlow,
   savePetToFirestore,
   sendPetCreationEmail,
-} from "./createPetFlow";
+} from "./flows/createPetFlow";
 import {
   getImapClient,
   getAliasEmailAddress,

--- a/functions/src/flows/createPetFlow.ts
+++ b/functions/src/flows/createPetFlow.ts
@@ -1,9 +1,9 @@
 import { Timestamp } from "firebase-admin/firestore";
 import { z } from "zod";
-import { sendEmail } from "./email";
-import { PetProfile } from "./types";
-import { db } from "./firebase";
-import { ai, EmptySchema, PetProfileSchema, PetProfileData } from "./genkit.config";
+import { sendEmail } from "../email";
+import { PetProfile } from "../types";
+import { db } from "../firebase";
+import { ai, EmptySchema, PetProfileSchema, PetProfileData } from "../genkit.config";
 
 // Zod schemas for input/output validation
 const CreatePetInputSchema = z.object({

--- a/functions/src/flows/generateDestinationFlow.ts
+++ b/functions/src/flows/generateDestinationFlow.ts
@@ -1,4 +1,4 @@
-import { ai, DestinationSchema, GenerateDestinationInputSchema } from "./genkit.config";
+import { ai, DestinationSchema, GenerateDestinationInputSchema } from "../genkit.config";
 
 const generateDestinationPrompt = ai.prompt<
   typeof GenerateDestinationInputSchema,

--- a/functions/src/flows/generateDiaryFlow.ts
+++ b/functions/src/flows/generateDiaryFlow.ts
@@ -1,4 +1,4 @@
-import { ai, GenerateDiaryInputSchema, DiarySchema } from "./genkit.config";
+import { ai, GenerateDiaryInputSchema, DiarySchema } from "../genkit.config";
 
 const generateDiaryPrompt = ai.prompt<
   typeof GenerateDiaryInputSchema,

--- a/functions/src/flows/generateDiaryImageFlow.ts
+++ b/functions/src/flows/generateDiaryImageFlow.ts
@@ -1,5 +1,5 @@
 import vertexAI from "@genkit-ai/vertexai";
-import { ai } from "./genkit.config";
+import { ai } from "../genkit.config";
 import { z } from "zod";
 
 const DiaryImageInputSchema = ai.defineSchema(


### PR DESCRIPTION
## Summary
- move all flow-related files into `src/flows`
- update imports and tests to new path
- document new directory structure

## Testing
- `npm --prefix functions run lint`
- `npm --prefix functions run test`


------
https://chatgpt.com/codex/tasks/task_e_6860abd0c6408331b85f2f54e2b46353