### PR TITLE
Expose Genkit flows as callable functions

### DIFF
--- a/functions/src/flows/createPetFlow.ts
+++ b/functions/src/flows/createPetFlow.ts
@@ -1,4 +1,5 @@
 import { Timestamp } from "firebase-admin/firestore";
+import { onCallGenkit } from "firebase-functions/v2/https";
 import { sendEmail } from "../email";
 import { PetProfile } from "../types";
 import { db } from "../firebase";
@@ -93,3 +94,7 @@ ${profile.introduction}
   await sendEmail(email, subject, body, undefined, undefined, { html: htmlBody });
   console.log(`Creation email sent to: ${email}`);
 }
+
+// Export callable Cloud Function for client access
+export const createPet = onCallGenkit(createPetFlow);
+

--- a/functions/src/flows/generateDestinationFlow.ts
+++ b/functions/src/flows/generateDestinationFlow.ts
@@ -1,3 +1,4 @@
+import { onCallGenkit } from "firebase-functions/v2/https";
 import { ai, DestinationSchema, GenerateDestinationInputSchema } from "../genkit.config";
 
 const generateDestinationPrompt = ai.prompt<
@@ -19,3 +20,8 @@ export const generateDestinationFlow = ai.defineFlow(
     return output;
   }
 );
+
+// Export callable Cloud Function for client access
+export const generateDestination = onCallGenkit(generateDestinationFlow);
+
+

--- a/functions/src/flows/generateDiaryFlow.ts
+++ b/functions/src/flows/generateDiaryFlow.ts
@@ -1,3 +1,4 @@
+import { onCallGenkit } from "firebase-functions/v2/https";
 import { ai, GenerateDiaryInputSchema, DiarySchema } from "../genkit.config";
 
 const generateDiaryPrompt = ai.prompt<
@@ -19,3 +20,8 @@ export const generateDiaryFlow = ai.defineFlow(
     return output;
   }
 );
+
+// Export callable Cloud Function for client access
+export const generateDiary = onCallGenkit(generateDiaryFlow);
+
+

--- a/functions/src/flows/generateDiaryImageFlow.ts
+++ b/functions/src/flows/generateDiaryImageFlow.ts
@@ -1,4 +1,5 @@
 import vertexAI from "@genkit-ai/vertexai";
+import { onCallGenkit } from "firebase-functions/v2/https";
 import { ai } from "../genkit.config";
 import { z } from "zod";
 
@@ -36,3 +37,8 @@ export const generateDiaryImageFlow = ai.defineFlow(
     return { url };
   }
 );
+
+// Export callable Cloud Function for client access
+export const generateDiaryImage = onCallGenkit(generateDiaryImageFlow);
+
+


### PR DESCRIPTION
## Summary
- allow client invocation of AI flows by wrapping them in `onCallGenkit`

## Testing
- `npm --prefix functions run lint`
- `npm --prefix functions run test`


------
https://chatgpt.com/codex/tasks/task_e_6860af5166dc8331b5b0ed98f8e1555a