### PR TITLE
feat: save demo entries

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,4 +1,4 @@
-import { onCallGenkit, onRequest } from "firebase-functions/v2/https";
+import { onCallGenkit, onRequest, onCall, HttpsError } from "firebase-functions/v2/https";
 import { onSchedule } from "firebase-functions/v2/scheduler";
 
 import { checkNewEmailsAndCreatePet } from "./emailService";
@@ -12,6 +12,7 @@ import { createPetFlow } from "./flows/createPetFlow";
 import { generateDestinationFlow } from "./flows/generateDestinationFlow";
 import { generateDiaryFlow } from "./flows/generateDiaryFlow";
 import { generateDiaryImageFlow } from "./flows/generateDiaryImageFlow";
+import { saveImageToStorage } from "./diaryHelpers";
 
 export { db } from "./firebase";
 
@@ -136,3 +137,13 @@ export const createPet = onCallGenkit(createPetFlow);
 export const generateDestination = onCallGenkit(generateDestinationFlow);
 export const generateDiary = onCallGenkit(generateDiaryFlow);
 export const generateDiaryImage = onCallGenkit(generateDiaryImageFlow);
+
+export const saveDemoImage = onCall({ region: "us-central1" }, async (request) => {
+  const dataUrl = request.data?.dataUrl as string | undefined;
+  if (!dataUrl) {
+    throw new HttpsError("invalid-argument", "dataUrl is required");
+  }
+  const date = new Date().toISOString().split("T")[0];
+  const storedUrl = await saveImageToStorage(dataUrl, "demo", date);
+  return { url: storedUrl };
+});

--- a/public/entries.html
+++ b/public/entries.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Saved Diaries - Travel Pet</title>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&display=swap" rel="stylesheet" />
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="font-sans bg-gradient-to-br from-gray-50 to-gray-200 min-h-screen flex items-center justify-center">
+  <div class="max-w-3xl w-full mx-auto my-8 bg-white p-6 rounded-lg shadow">
+    <div class="flex justify-between items-center mb-6">
+      <h1 class="text-xl font-bold">保存された日記一覧</h1>
+      <a href="index.html" class="text-sm text-blue-600 underline">戻る</a>
+    </div>
+    <div id="entriesList" class="space-y-6"></div>
+    <div class="flex justify-center mt-6">
+      <button id="loadMore" class="px-4 py-2 text-sm text-white rounded" style="background-color: #75b1ae">もっと読み込む</button>
+    </div>
+  </div>
+
+  <!-- Firebase SDKs -->
+  <script src="/__/firebase/9.0.0/firebase-app-compat.js"></script>
+  <script src="/__/firebase/9.0.0/firebase-firestore-compat.js"></script>
+  <script src="/__/firebase/init.js?useEmulator=true"></script>
+  <script src="entries.js?v=1"></script>
+</body>
+</html>

--- a/public/entries.js
+++ b/public/entries.js
@@ -1,0 +1,45 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const db = firebase.app().firestore();
+  const entriesList = document.getElementById('entriesList');
+  const loadMoreBtn = document.getElementById('loadMore');
+  let lastDoc = null;
+
+  async function loadEntries() {
+    let query = db.collection('demoDiaries').orderBy('createdAt', 'desc').limit(10);
+    if (lastDoc) {
+      query = query.startAfter(lastDoc);
+    }
+    const snap = await query.get();
+    if (snap.empty) {
+      loadMoreBtn.disabled = true;
+      return;
+    }
+    lastDoc = snap.docs[snap.docs.length - 1];
+
+    const html = snap.docs
+      .map((doc) => {
+        const d = doc.data();
+        const name = d.profile?.name ?? '';
+        const loc = d.destination?.selected_location ?? '';
+        const diary = d.diary ?? '';
+        const diaryHtml = diary.replace(/\n/g, '<br>');
+        const image = d.imageUrl
+          ? `<img src="${d.imageUrl}" class="max-w-full h-auto mt-2" />`
+          : '';
+        return `
+          <div class="border rounded p-4">
+            <div class="font-medium">${name} - ${loc}</div>
+            <details class="mt-1 text-sm">
+              <summary class="cursor-pointer">日記を読む</summary>
+              <div class="whitespace-pre-wrap mt-1">${diaryHtml}</div>
+              ${image}
+            </details>
+          </div>`;
+      })
+      .join('');
+    entriesList.insertAdjacentHTML('beforeend', html);
+  }
+
+  loadMoreBtn.addEventListener('click', loadEntries);
+  loadEntries();
+});

--- a/public/index.html
+++ b/public/index.html
@@ -43,11 +43,16 @@
       <h2 class="text-lg font-semibold mb-4">Error</h2>
       <pre id="errorOutput"></pre>
     </div>
+    <div id="savedEntries" class="p-6 mt-6 border rounded-lg bg-gray-50">
+      <h2 class="text-lg font-semibold mb-4">Recent Entries</h2>
+      <div id="entriesList" class="space-y-4 text-sm"></div>
+    </div>
   </div>
 
   <!-- 1) Compat SDKs for Hosting -->
   <script src="/__/firebase/9.0.0/firebase-app-compat.js"></script>
   <script src="/__/firebase/9.0.0/firebase-functions-compat.js"></script>
+  <script src="/__/firebase/9.0.0/firebase-firestore-compat.js"></script>
   <!-- 2) Auto-initialize + auto-emulator wiring -->
   <script src="/__/firebase/init.js?useEmulator=true"></script>
 

--- a/public/index.html
+++ b/public/index.html
@@ -16,11 +16,12 @@
       <br />
       <strong>注意:</strong> このデモは実際のメール送信を行いません。生成された内容は画面上に表示されます。
     </div>
-    <div class="flex justify-center">
+    <div class="flex flex-col items-center space-y-2">
       <button id="generateButton" class="flex items-center px-5 py-2 text-white rounded hover:opacity-90 disabled:opacity-60" style="background-color: #75b1ae">
         <span>ペットと日記を生成する</span>
         <span id="buttonSpinner" class="ml-2 hidden border-2 border-white border-t-transparent rounded-full w-4 h-4 animate-spin"></span>
       </button>
+      <a href="entries.html" class="text-sm text-blue-600 underline">保存された日記を見る</a>
     </div>
 
     <div id="petDetails" class="hidden p-6 mt-6 border rounded-lg bg-gray-50">
@@ -42,10 +43,6 @@
     <div id="errorDetails" class="hidden p-6 mt-6 border rounded-lg bg-red-50 text-red-600">
       <h2 class="text-lg font-semibold mb-4">Error</h2>
       <pre id="errorOutput"></pre>
-    </div>
-    <div id="savedEntries" class="p-6 mt-6 border rounded-lg bg-gray-50">
-      <h2 class="text-lg font-semibold mb-4">Recent Entries</h2>
-      <div id="entriesList" class="space-y-4 text-sm"></div>
     </div>
   </div>
 

--- a/public/script.js
+++ b/public/script.js
@@ -14,8 +14,34 @@ document.addEventListener('DOMContentLoaded', () => {
   const diaryDetailsDiv = document.getElementById('diaryDetails');
   const imageDetailsDiv = document.getElementById('imageDetails');
   const errorDetailsDiv = document.getElementById('errorDetails');
+  const entriesList = document.getElementById('entriesList');
+
+  const db = firebase.app().firestore();
 
   const functions = firebase.app().functions('us-central1');
+
+  async function loadEntries() {
+    const snap = await db
+      .collection('demoDiaries')
+      .orderBy('createdAt', 'desc')
+      .limit(5)
+      .get();
+
+    entriesList.innerHTML = snap.docs
+      .map((doc) => {
+        const d = doc.data();
+        const name = d.profile?.name ?? '';
+        const loc = d.destination?.selected_location ?? '';
+        const diary = d.diary ?? '';
+        const image = d.imageUrl
+          ? `<img src="${d.imageUrl}" class="max-w-full h-auto mt-2" />`
+          : '';
+        return `<div class="p-4 border rounded"><div class="font-medium">${name} - ${loc}</div><div class="mt-1 whitespace-pre-wrap">${diary}</div>${image}</div>`;
+      })
+      .join('');
+  }
+
+  loadEntries();
 
   function displayPetDetails(profile) {
     petOutput.innerHTML = `
@@ -100,6 +126,15 @@ document.addEventListener('DOMContentLoaded', () => {
       imageOutput.src = image.url;
       imageDetailsDiv.classList.remove('hidden');
       imageDetailsDiv.scrollIntoView({ behavior: 'smooth' });
+
+      await db.collection('demoDiaries').add({
+        createdAt: firebase.firestore.FieldValue.serverTimestamp(),
+        profile: petProfile,
+        destination,
+        diary: diary.diary,
+        imageUrl: image.url,
+      });
+      loadEntries();
     } catch (error) {
       console.error(error);
       errorOutput.textContent = error.message;

--- a/public/script.js
+++ b/public/script.js
@@ -14,34 +14,9 @@ document.addEventListener('DOMContentLoaded', () => {
   const diaryDetailsDiv = document.getElementById('diaryDetails');
   const imageDetailsDiv = document.getElementById('imageDetails');
   const errorDetailsDiv = document.getElementById('errorDetails');
-  const entriesList = document.getElementById('entriesList');
-
   const db = firebase.app().firestore();
 
   const functions = firebase.app().functions('us-central1');
-
-  async function loadEntries() {
-    const snap = await db
-      .collection('demoDiaries')
-      .orderBy('createdAt', 'desc')
-      .limit(5)
-      .get();
-
-    entriesList.innerHTML = snap.docs
-      .map((doc) => {
-        const d = doc.data();
-        const name = d.profile?.name ?? '';
-        const loc = d.destination?.selected_location ?? '';
-        const diary = d.diary ?? '';
-        const image = d.imageUrl
-          ? `<img src="${d.imageUrl}" class="max-w-full h-auto mt-2" />`
-          : '';
-        return `<div class="p-4 border rounded"><div class="font-medium">${name} - ${loc}</div><div class="mt-1 whitespace-pre-wrap">${diary}</div>${image}</div>`;
-      })
-      .join('');
-  }
-
-  loadEntries();
 
   function displayPetDetails(profile) {
     petOutput.innerHTML = `
@@ -137,7 +112,6 @@ document.addEventListener('DOMContentLoaded', () => {
         diary: diary.diary,
         imageUrl: saved.url,
       });
-      loadEntries();
     } catch (error) {
       console.error(error);
       errorOutput.textContent = error.message;

--- a/public/script.js
+++ b/public/script.js
@@ -127,12 +127,15 @@ document.addEventListener('DOMContentLoaded', () => {
       imageDetailsDiv.classList.remove('hidden');
       imageDetailsDiv.scrollIntoView({ behavior: 'smooth' });
 
+      const saveImage = functions.httpsCallable('saveDemoImage');
+      const { data: saved } = await saveImage({ dataUrl: image.url });
+
       await db.collection('demoDiaries').add({
         createdAt: firebase.firestore.FieldValue.serverTimestamp(),
         profile: petProfile,
         destination,
         diary: diary.diary,
-        imageUrl: image.url,
+        imageUrl: saved.url,
       });
       loadEntries();
     } catch (error) {


### PR DESCRIPTION
## Summary
- save demo diary data in Firestore
- fetch latest entries when the page loads
- add section in demo site to show recent entries

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68621f712578833187f85fafab7a4ce2